### PR TITLE
Fix digitalWrite not activating pull-up on ESP8266 Arduino Core 2.6.1.

### DIFF
--- a/ClickButton.cpp
+++ b/ClickButton.cpp
@@ -106,9 +106,14 @@ ClickButton::ClickButton(uint8_t buttonPin, boolean activeType, boolean internal
   multiclickTime = 250;           // Time limit for multi clicks
   longClickTime  = 1000;          // time until "long" click register
   changed        = false;
-  pinMode(_pin, INPUT);
+  //pinMode(_pin, INPUT);
   // Turn on internal pullup resistor if applicable
-  if (_activeHigh == LOW && internalPullup == CLICKBTN_PULLUP) digitalWrite(_pin,HIGH);
+  //if (_activeHigh == LOW && internalPullup == CLICKBTN_PULLUP) digitalWrite(_pin,HIGH);
+  if (_activeHigh == LOW && internalPullup == CLICKBTN_PULLUP) 
+    pinMode(_pin, INPUT_PULLUP);
+  else
+    pinMode(_pin, INPUT);
+
 }
 
 


### PR DESCRIPTION
According to [this documentation](https://www.arduino.cc/en/Tutorial/DigitalPins), 

> Prior to Arduino 1.0.1, it was possible to configure the internal pull-ups in the following manner:
```
pinMode(pin, INPUT);           // set pin to input
digitalWrite(pin, HIGH);       // turn on pullup resistors
```

Now, according to the same document linked to above, it says we should be:

> setting the pinMode() as INPUT_PULLUP.
